### PR TITLE
Remove the snapshot aspect of the builder - too niche, closing #7

### DIFF
--- a/docs/Builder.md
+++ b/docs/Builder.md
@@ -12,11 +12,6 @@
 
 * Method ```tryNext( Element? orElse = null ) -> Element?``` - if an Element is ready for construction it builds and returns it, otherwise it returns the value in ```orElse``` instead.
 
-* Method ```snapshot() -> Element``` - all open states are automatically but temporarily completed;
-if an Element is ready for construction after the auto-completion, it is constructed and the result will be returned, otherwise an exception is raised; the temporarily closed states are restored to their previous state. Use ```this.isInProgress()``` to check whether it is safe to call this method.
-
-* Method ```trySnapshot( Element? orElse = null ) -> Element?``` - as for ```snapshot``` but never raises an exception but returns the value in```orElse``` instead.
-
 * Method ```include( Element value, Boolean checkMutability = false )``` - adds and shares this Element into the in-progress build. The mutability of the included value is checked depending on the ```checkMutability``` flag. It is **not** an error to mix mutability this way but an occasionally important feature.
 
 * Method ```reconstruct( Element value )``` - replays a series of events which would construct the Element supplied but does so inside the in-progress build. This is effectively the same as ```this.processEvents( value.toEventIterator() )```

--- a/java/src/com/steelypip/powerups/jinxml/Builder.java
+++ b/java/src/com/steelypip/powerups/jinxml/Builder.java
@@ -57,22 +57,6 @@ public interface Builder extends Iterator< Element >, EventHandler {
 	default Element tryNext() {
 		return this.tryNext( null );
 	}
-
-	/**
-	 * All open states are automatically but temporarily completed; if an Element is ready for construction after the 
-	 * auto-completion, it is constructed and the result will be returned, otherwise an exception is raised; the 
-	 * temporarily closed states are restored to their previous state. Use this.isInProgress() to check whether it 
-	 * is safe to call this method.
-	 * @return the element
-	 */
-	Element snapshot(); 
-	
-	/**
-	 * As for snapshot but never raises an exception but returns the value otherwise instead.
-	 * @param otherwise the value to return if there are 
-	 * @return the newly constructed element
-	 */
-	Element trySnapshot( Element otherwise );
 	
 	/**
 	 * Closes the current element-under-construction and returns it.

--- a/java/src/com/steelypip/powerups/jinxml/stdmodel/StdBuilder.java
+++ b/java/src/com/steelypip/powerups/jinxml/stdmodel/StdBuilder.java
@@ -205,22 +205,6 @@ public class StdBuilder implements Builder {
 	}
 
 	@Override
-	public Element snapshot() {
-		final Element e = root.getFirstChild();
-		if ( e != null ) {
-			return this.mutable_flag ? e.deepMutableCopy() : e.deepFreeze();
-		} else {
-			throw new IllegalStateException( "No events processed, cannot take a snapshot" );
-		}
-	}
-
-	@Override
-	public Element trySnapshot( Element otherwise ) {
-		final Element e = root.getFirstChild();
-		return e != null ? ( this.mutable_flag ? e.deepMutableCopy() : e.deepFreeze() ) : otherwise;
-	}
-
-	@Override
 	public void include( @NonNull String selector, Element child, boolean checkMutability ) {
 		if ( checkMutability ) {
 			//	Counter-intuitive test: use == because the two sides have exactly opposite meanings.

--- a/java/test/com/steelypip/powerups/jinxml/implementation/Test_StdBuilder.java
+++ b/java/test/com/steelypip/powerups/jinxml/implementation/Test_StdBuilder.java
@@ -168,22 +168,6 @@ public class Test_StdBuilder {
 	}
 	
 	@Test
-	public void snapshot_OK() {
-		builder.startArrayEvent();
-		assertEquals( Element.ARRAY_ELEMENT_NAME, builder.snapshot().getName() );
-	}
-	
-	@Test( expected=Exception.class )
-	public void snapshot_Fail() {
-		builder.snapshot();
-	}
-	
-	@Test
-	public void trySnapshot_Otherwise() {
-		assertEquals( "me", builder.trySnapshot( Element.newElement( "me" ) ).getName() );
-	}
-	
-	@Test
 	public void tryNext_Otherwise() {
 		assertEquals( "me", builder.tryNext( Element.newElement( "me" ) ).getName() );
 	}


### PR DESCRIPTION
Strip out the snapshot capability - implementation, tests and documentation.